### PR TITLE
Issue#1 Refactored Constants to CamelCase to Match Naming Conventions

### DIFF
--- a/jme3-android-examples/src/main/java/jme3test/android/TestAndroidSensors.java
+++ b/jme3-android-examples/src/main/java/jme3test/android/TestAndroidSensors.java
@@ -42,12 +42,12 @@ public class TestAndroidSensors extends SimpleApplication implements ActionListe
     // flag to allow for the joystick axis to be calibrated on startup
     private boolean initialCalibrationComplete = false;
     // mappings used for onAnalog
-    private final String ORIENTATION_X_PLUS = "Orientation_X_Plus";
-    private final String ORIENTATION_X_MINUS = "Orientation_X_Minus";
-    private final String ORIENTATION_Y_PLUS = "Orientation_Y_Plus";
-    private final String ORIENTATION_Y_MINUS = "Orientation_Y_Minus";
-    private final String ORIENTATION_Z_PLUS = "Orientation_Z_Plus";
-    private final String ORIENTATION_Z_MINUS = "Orientation_Z_Minus";
+    private final String orientationXPlus = "Orientation_X_Plus";
+    private final String orientationXMinus = "Orientation_X_Minus";
+    private final String orientationYPlus = "Orientation_Y_Plus";
+    private final String orientationYMinus  = "Orientation_Y_Minus";
+    private final String orientationZPlus = "Orientation_Z_Plus";
+    private final String orientationZMinus = "Orientation_Z_Minus";
 
 
     // variables to save the current rotation


### PR DESCRIPTION
Issue [#1 ](https://github.com/tanveer27/jmonkeyengineW25/issues/1) is resolved
Renamed the orientation-related constants from uppercase **snake_case** to **camelCase** to comply with the required naming convention (^[a-z][a-zA-Z0-9]*$)
Changes made:
There were six  instances where this issue occurred and now is rectified