### PR TITLE
Fix Type 1 clone:Refactored Matrix Serialization to Remove Code Duplication

### DIFF
--- a/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/RawLayout.java
+++ b/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/RawLayout.java
@@ -64,6 +64,7 @@ public class RawLayout extends BufferLayout {
             public void write(BufferLayout serializer, ByteBuffer bbf, byte[] obj) {
                 bbf.put(obj);
             }
+
         });
 
         registerSerializer(new ObjectSerializer<Integer>(Integer.class) {
@@ -381,6 +382,9 @@ public class RawLayout extends BufferLayout {
             }
         });
 
+
+
+
         registerSerializer(new ObjectSerializer<Matrix3f>(Matrix3f.class) {
             @Override
             public int length(BufferLayout serializer, Matrix3f obj) {
@@ -396,20 +400,7 @@ public class RawLayout extends BufferLayout {
 
             @Override
             public void write(BufferLayout serializer, ByteBuffer bbf, Matrix3f obj) {
-                obj.getColumn(0, tmp);
-                bbf.putFloat(tmp.x);
-                bbf.putFloat(tmp.y);
-                bbf.putFloat(tmp.z);
-
-                obj.getColumn(1, tmp);
-                bbf.putFloat(tmp.x);
-                bbf.putFloat(tmp.y);
-                bbf.putFloat(tmp.z);
-
-                obj.getColumn(2, tmp);
-                bbf.putFloat(tmp.x);
-                bbf.putFloat(tmp.y);
-                bbf.putFloat(tmp.z);
+                writeMatrix3f(bbf, obj, tmp);
             }
         });
 
@@ -471,20 +462,7 @@ public class RawLayout extends BufferLayout {
             @Override
             public void write(BufferLayout serializer, ByteBuffer bbf, Matrix3f[] objs) {
                 for (Matrix3f obj : objs) {
-                    obj.getColumn(0, tmp);
-                    bbf.putFloat(tmp.x);
-                    bbf.putFloat(tmp.y);
-                    bbf.putFloat(tmp.z);
-
-                    obj.getColumn(1, tmp);
-                    bbf.putFloat(tmp.x);
-                    bbf.putFloat(tmp.y);
-                    bbf.putFloat(tmp.z);
-
-                    obj.getColumn(2, tmp);
-                    bbf.putFloat(tmp.x);
-                    bbf.putFloat(tmp.y);
-                    bbf.putFloat(tmp.z);
+                    writeMatrix3f(bbf, obj, tmp);
                 }
             }
         });
@@ -533,6 +511,23 @@ public class RawLayout extends BufferLayout {
             }
         });
 
+    }
+
+    private void writeMatrix3f(ByteBuffer bbf, Matrix3f obj, Vector3f tmp) {
+        obj.getColumn(0, tmp);
+        bbf.putFloat(tmp.x);
+        bbf.putFloat(tmp.y);
+        bbf.putFloat(tmp.z);
+
+        obj.getColumn(1, tmp);
+        bbf.putFloat(tmp.x);
+        bbf.putFloat(tmp.y);
+        bbf.putFloat(tmp.z);
+
+        obj.getColumn(2, tmp);
+        bbf.putFloat(tmp.x);
+        bbf.putFloat(tmp.y);
+        bbf.putFloat(tmp.z);
     }
 
     @Override


### PR DESCRIPTION
Extracted common matrix serialization logic into helper method **writeMatrix3f()** and  to eliminate duplicate code in RawLayout.java  at line [398](https://github.com/SOEN6431Winter2025/jmonkeyengineW25/blob/49f2873e49639e6fff5c5290c66abb968b98c62d/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/RawLayout.java#L49) and [473](https://github.com/SOEN6431Winter2025/jmonkeyengineW25/blob/49f2873e49639e6fff5c5290c66abb968b98c62d/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/RawLayout.java#L49) It resolves the Type 1 clone identified using PMD.   Improved maintainability, readability, and efficiency. Fix:#22 